### PR TITLE
Update DeepInfer.py

### DIFF
--- a/DeepInfer/DeepInfer.py
+++ b/DeepInfer/DeepInfer.py
@@ -337,8 +337,8 @@ class DeepInferWidget:
         jsonFiles.sort(cmp=lambda x, y: cmp(os.path.basename(x), os.path.basename(y)))
         self.jsonModels = []
         for fname in jsonFiles:
-            fp = file(fname, "r")
-            j = json.load(fp, object_pairs_hook=OrderedDict)
+            with open(fname, "r") as fp:
+                j = json.load(fp, object_pairs_hook=OrderedDict)
             if j['docker']['digest'] in digests:
                 self.jsonModels.append(j)
             else:


### PR DESCRIPTION
fixing the json file reading to close afterwards, otherwise when the digest doesn't match, the program tries to run ```os.remove``` on an open file